### PR TITLE
Camera lerp adjustment + death scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,26 @@ licensed under the **GNU Affero General Public License v3.0 or later**, as is th
 This is an unofficial port, not affiliated with or endorsed by upstream — report issues
 with this port here, never to upstream.
 
+### Copyright
+
+This port is a fork, so the two copyrights sit side by side under the one license:
+
+- **Copyright Martin Törnqvist** &lt;m.tornq@gmail.com&gt; — Infra Arcana itself, and every
+  file in this repository derived from it.
+- **Copyright Werewolf Camp** — the Android port's own source files, i.e. those with no
+  upstream counterpart (the touch interface, display separation, and the rest of the
+  mobile work).
+
+Each source file's header names its holder, and carries
+`SPDX-License-Identifier: AGPL-3.0-or-later` either way. New port-original files take the
+Werewolf Camp line; files inherited from upstream keep Martin's, whether or not this port
+has modified them.
+
 ### Credits
 
 - **Infra Arcana** by Martin Törnqvist — the game itself: code, art, audio and design.
   [Homepage](https://sites.google.com/site/infraarcana) ·
   [Source](https://gitlab.com/martin-tornqvist/ia). AGPL-3.0-or-later.
+- **Android port** by Werewolf Camp — touch interface and mobile build. AGPL-3.0-or-later.
 - **SDL2 / SDL2_image / SDL2_mixer** — Sam Lantinga and contributors (zlib license), vendored.
 - Per-file asset and library licenses ship with the game data in `installed_files/`.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -58,8 +58,8 @@ android {
         applicationId = "camp.werewolf.infraarcana"
         minSdk = 24
         targetSdk = 35
-        versionCode = 23000006
-        versionName = "23.0.0.6"
+        versionCode = 23000007
+        versionName = "23.0.0.7"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")

--- a/fastlane/metadata/android/en-US/changelogs/23000007.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23000007.txt
@@ -1,0 +1,7 @@
+- Smoothed camera follow
+- Eased camera return after drag-to-look
+- Tightened menu entry tap surface
+- Added screen shake to hits and kicks
+- Strengthened explosion shake
+- Added death sequence, tap to skip
+- Paced frames to the display refresh

--- a/include/action_bar.hpp
+++ b/include/action_bar.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/action_list_state.hpp
+++ b/include/action_list_state.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/actions_config.hpp
+++ b/include/actions_config.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/context_pins.hpp
+++ b/include/context_pins.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/death_cinematic.hpp
+++ b/include/death_cinematic.hpp
@@ -1,0 +1,22 @@
+// =============================================================================
+// Copyright Werewolf Camp
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// =============================================================================
+
+#ifndef DEATH_CINEMATIC_HPP
+#define DEATH_CINEMATIC_HPP
+
+namespace death_cinematic
+{
+// Zooms slowly in on the player as the map drains to red, then fades to
+// black. Only the map reddens - the interface keeps its colors. Blocks
+// until it has played out, so its pacing never depends on when the player
+// taps. Call reset once the game state is gone.
+void run();
+
+void reset();
+
+}  // namespace death_cinematic
+
+#endif  // DEATH_CINEMATIC_HPP

--- a/include/descr_column.hpp
+++ b/include/descr_column.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/dpad.hpp
+++ b/include/dpad.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/easing.hpp
+++ b/include/easing.hpp
@@ -1,0 +1,37 @@
+// =============================================================================
+// Copyright Werewolf Camp
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// =============================================================================
+
+#ifndef EASING_HPP
+#define EASING_HPP
+
+// Shaping curves for animation. Each takes and returns progress from 0 to 1.
+namespace ease
+{
+// Creeps, then rushes
+inline float in(const float t)
+{
+        return t * t;
+}
+
+// Moves at once, then settles
+inline float out(const float t)
+{
+        const float u = 1.0f - t;
+
+        return 1.0f - (u * u);
+}
+
+// As out, but settling harder - the last of the motion is very slow
+inline float cubic_out(const float t)
+{
+        const float u = 1.0f - t;
+
+        return 1.0f - (u * u * u);
+}
+
+}  // namespace ease
+
+#endif  // EASING_HPP

--- a/include/fade.hpp
+++ b/include/fade.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/io.hpp
+++ b/include/io.hpp
@@ -149,6 +149,10 @@ extern bool g_allow_render;
 #endif  // NDEBUG
 void update_screen();
 
+// How long the last present spent blocked on vblank, clearing it so it is
+// only ever taken off one delay (see io::sleep)
+uint32_t take_last_present_block_ms();
+
 void clear_screen();
 
 std::string sdl_pref_dir();
@@ -254,11 +258,6 @@ void draw_rectangles_filled(
         const Color& color,
         uint8_t alpha = SDL_ALPHA_OPAQUE);
 
-void draw_rectangle_filled_mod_blending(
-        R px_rect,
-        const Color& color,
-        uint8_t alpha = SDL_ALPHA_OPAQUE);
-
 void draw_logo();
 
 // Draws a description "box" for items, spells, etc. The parameter lines may be
@@ -283,6 +282,11 @@ void clear_all_flash_animations();
 void sleep(uint32_t duration);
 
 void clear_input();
+
+// Whether a tap or key press is waiting, WITHOUT blocking for one (unlike
+// read_input). Drains the queue either way, so it also serves as the
+// clear_input of a loop that runs its own animation.
+bool poll_any_input();
 
 InputData read_input();
 

--- a/include/io_display.hpp
+++ b/include/io_display.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 
+#include "colors.hpp"
 #include "panel.hpp"
 #include "pos.hpp"
 #include "rect.hpp"
@@ -158,13 +159,35 @@ void set_map_follow_drawn_whole_cells(const P& cells);
 // camera crosses a cell. Returns whether to present.
 bool step_map_animations();
 
-// Shakes the map for a moment, settling back to still - an explosion going
-// off (see explosion::run). Like the camera follow this only moves the
-// window into the map texture, costing a composite per step and never a
-// redraw, and is advanced by step_map_animations. The amplitude is in
-// logical pixels, capped by the map's one cell of overscan. NOTE: The clock
-// starts at the first step, not here.
+// Magnifies the composited map about a point, in logical pixels within the
+// map panel. 1.0 is unzoomed. Samples content already drawn, so it costs
+// nothing but the copy - and cannot zoom OUT, where there is none.
+void set_map_zoom(float zoom, const P& center_px);
+
+// Multiplies the map by a color as it is composited, and nothing else on
+// screen. No tint is pure 255,255,255 - NOT colors::white(), which is
+// c0c0c0 and would darken the map.
+void set_map_tint(const Color& color);
+
+void clear_map_tint();
+
+// Radial darkness closing on a point of the map, in logical pixels.
+// open_frac 1.0 leaves the map clear, 0.0 blacks it out. Applied as the map
+// is composited, so the log and the panels stay clear of it.
+void set_map_vignette(const P& center_px, float open_frac);
+
+void clear_map_vignette();
+
+// Shakes the map for a moment, settling back to still. Only moves the
+// window into the map texture, so it never costs a redraw. Amplitude is
+// capped by max_map_shake_px, a new shake replaces the running one, and the
+// clock starts at the first step. See screen_shake for what events use.
 void start_map_shake(int amplitude_px, uint32_t duration_ms);
+
+// The largest displacement a shake may use. The map texture reserves this
+// beyond the camera's cell of overscan, so a shake is never clipped by a
+// lagging camera; amplitudes are capped to it.
+int max_map_shake_px();
 
 bool is_map_shake_active();
 

--- a/include/io_display.hpp
+++ b/include/io_display.hpp
@@ -22,11 +22,9 @@
 // centering offsets are applied only at composite time.
 //
 // This allows the map, the message log, and the side stats panel to be
-// positioned (and eventually scaled/panned) independently of each other -
-// e.g. sliding the side panel to the other side of the screen on Android.
-//
-// On desktop, all composite offsets are zero and the result is pixel
-// identical to drawing directly to the window.
+// positioned and panned independently of each other - e.g. sliding the side
+// panel to the other side of the screen, and scrolling the map under the
+// overlays as the camera follows the player.
 // -----------------------------------------------------------------------------
 namespace io
 {
@@ -129,47 +127,50 @@ P display_px_offset(Display display);
 P current_display_draw_px_offset();
 
 // Sub-cell scroll of the map display content, in logical pixels. This is
-// the fractional part of two finger map panning - whole cells shift the
+// the fractional part of manual map panning - whole cells shift the
 // viewport (see viewport::pan), while this offset slides the composited map
 // content smoothly between cell boundaries. The map display is rendered
 // with one cell of overscan beyond each map panel edge, so the sliding
 // edges always show content.
 void set_map_scroll_px_offset(const P& px_offset);
 
-P map_scroll_px_offset();
+// Puts the camera this far behind its drawn framing, in logical pixels, and
+// eases it back to zero by a fraction of what is left per present.
+//
+// ADDS to the current offset, so the camera's screen position stays
+// continuous. Unbounded - the drawn view origin takes on whatever exceeds
+// the composite's one cell (see map_follow_whole_cells). The clock starts
+// at the first present, not here.
+void offset_map_follow(const P& px_offset);
 
-// A short tween of the map scroll offset from the given value back to
-// zero, so that the camera SLIDES when the viewport steps while following
-// the player, instead of snapping tile to tile (see viewport::show).
-// Stepped from the input/render loop (non blocking). NOTE: The tween's
-// clock starts at the first step, not here - see step_map_follow_tween.
-void start_map_follow_tween(const P& px_offset);
+// Whether the camera is still behind its framing
+bool is_map_follow_active();
 
-// Advances the tween; returns whether the offset changed (the screen
-// should then be re-composited). Stepping it costs a composite and a
-// present - the map display is NOT redrawn, only the window into it moves.
-bool step_map_follow_tween();
+// Whole cells of the lag beyond the one cell the composite can carry. The
+// drawn view origin must take these on (see viewport::show).
+P map_follow_whole_cells();
 
-// Whether a camera follow tween is running. While it is, the render loop
-// keeps to compositing: a full state redraw mid-tween is expensive enough
-// on a slow device to eat the whole tween in one frame.
-bool is_map_follow_tween_active();
+// The whole-cell part the map display was last drawn with. The composite
+// offsets by the rest.
+void set_map_follow_drawn_whole_cells(const P& cells);
+
+// Advances the camera and the shake, redrawing the map display when the
+// camera crosses a cell. Returns whether to present.
+bool step_map_animations();
 
 // Shakes the map for a moment, settling back to still - an explosion going
-// off (see explosion::run). Like the camera tween this only moves the
-// window into the map texture, so it costs a composite per step and never
-// a redraw, and it is stepped by whatever loop is running: io::sleep
-// animates it through the blast's own delay, and the input loop finishes
-// it. The amplitude is in logical pixels, and is capped by the map's one
-// cell of overscan. NOTE: The clock starts at the first step, not here.
+// off (see explosion::run). Like the camera follow this only moves the
+// window into the map texture, costing a composite per step and never a
+// redraw, and is advanced by step_map_animations. The amplitude is in
+// logical pixels, capped by the map's one cell of overscan. NOTE: The clock
+// starts at the first step, not here.
 void start_map_shake(int amplitude_px, uint32_t duration_ms);
-
-bool step_map_shake();
 
 bool is_map_shake_active();
 
-// E.g. manual panning takes over the scroll offset
-void cancel_map_follow_tween();
+// Camera home immediately, no easing. Call viewport::cut_to or
+// viewport::cut_camera instead - viewport owns the whole-cell half.
+void cancel_map_follow();
 
 // Translates a window pixel position (e.g. a touch position) to logical
 // screen pixels, i.e. the coordinate space of panels and display textures.
@@ -180,7 +181,7 @@ P window_px_to_logical_px(const P& window_px);
 R panel_logical_px_rect(Panel panel);
 
 // Slides the side stats panel to the other side of the screen with an
-// animated tween (Back.out easing), repositioning the map and log displays
+// animated tween (Cubic.out easing), repositioning the map and log displays
 // accordingly. Persists the new layout in the config.
 void run_side_panel_slide_animation();
 

--- a/include/io_icons.hpp
+++ b/include/io_icons.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/menu_descr_page.hpp
+++ b/include/menu_descr_page.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/menu_page.hpp
+++ b/include/menu_page.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================
@@ -42,6 +42,10 @@ void forget_remembered_marked_entries();
 
 constexpr int g_divider_min_w = 28;
 constexpr int g_divider_max_w = 56;
+
+// Reach beyond a menu entry's text that still counts as tapping it, in gui
+// cells. Shared with the menu popups, which mark entries the same way.
+constexpr int g_entry_tap_margin = 2;
 
 // One row of a menu page. The label may start with a stylistic "(x)" key
 // prefix, which is drawn in the menu key colors. The value is an optional

--- a/include/menu_page.hpp
+++ b/include/menu_page.hpp
@@ -161,7 +161,7 @@ protected:
 
         // Whether the divider rules above and below the list are drawn.
         // The list block extents are computed either way - they are also
-        // the row tap zone and the scroll fade area.
+        // the scroll fade area.
         virtual bool show_list_dividers() const
         {
                 return true;
@@ -183,8 +183,11 @@ private:
         // The row extents span the whole list block (the divider rule
         // width), not just the labels - the rows are finger targets.
         int m_drawn_list_y0 {-1};
-        int m_drawn_row_x0 {-1};
-        int m_drawn_row_x1 {-1};
+
+        // Left edge of the drawn entries, and each visible entry's right
+        // edge (label through value column) - the tap zone, see try_tap
+        int m_drawn_entry_x0 {-1};
+        std::vector<int> m_drawn_entry_x1 {};
 };
 
 #endif  // MENU_PAGE_HPP

--- a/include/msg_log.hpp
+++ b/include/msg_log.hpp
@@ -137,6 +137,10 @@ bool is_waiting_prompt();
 // direction query (see query::dir) is answered by swiping.
 bool is_waiting_more_prompt();
 
+// Draws the "more" prompt's hint WITHOUT waiting for input, for a sequence
+// that reads input itself (see death_cinematic).
+void set_more_prompt_hint_shown(bool is_shown);
+
 // Marks that a log query is waiting for an answer (see query::yes_or_no),
 // so that the query text is not overwritten (see is_waiting_prompt)
 void set_waiting_query(bool waiting);

--- a/include/popup.hpp
+++ b/include/popup.hpp
@@ -19,11 +19,6 @@
 
 namespace popup
 {
-// The screen gui cell area of the most recently drawn popup box (used for
-// closing the popup when tapping outside it on touch devices). Has negative
-// coordinates if no popup has been drawn.
-R box_area();
-
 // Tappable confirm/cancel button areas of the most recently drawn popup
 // (gui cells; negative coordinates when not present)
 R ok_button_area();

--- a/include/screen_shake.hpp
+++ b/include/screen_shake.hpp
@@ -1,0 +1,30 @@
+// =============================================================================
+// Copyright Werewolf Camp
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// =============================================================================
+
+#ifndef SCREEN_SHAKE_HPP
+#define SCREEN_SHAKE_HPP
+
+#include <cstdint>
+
+// What each event does to the screen, over io::start_map_shake. Amplitudes
+// and durations live here, not at the call sites, so the shakes stay in
+// proportion. They differ only in those two - every shake rattles both
+// axes, and none is ever directional (a directional throw travels the way a
+// camera step does, and reads as the view sliding).
+namespace screen_shake
+{
+// A weapon hit, a kick, bashing a door or statue - short and light
+void on_player_blow();
+
+// Longer and heavier, scaled by the fraction of max hp lost
+void on_player_damaged(int dmg, int max_hp);
+
+// The hardest jolt in the game, lasting the blast animation
+void on_explosion(uint32_t duration_ms);
+
+}  // namespace screen_shake
+
+#endif  // SCREEN_SHAKE_HPP

--- a/include/scrollbar.hpp
+++ b/include/scrollbar.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/text_page.hpp
+++ b/include/text_page.hpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/include/viewport.hpp
+++ b/include/viewport.hpp
@@ -33,6 +33,11 @@ void show(
 // placing the aim reticle.
 void cut_to(const P& map_pos);
 
+// Whether the centering point is biased away from the overlays that take a
+// column (the stats panel and the movement pad). Turn it off once they have
+// left the screen, and the camera glides the player to dead center.
+void set_center_bias_enabled(bool is_enabled);
+
 // Brings the drawn view origin up to a gliding camera, same target. Driven
 // by the render loop, since not every state re-centers the view every frame
 // (the aim marker only does so when its position leaves the view).

--- a/include/viewport.hpp
+++ b/include/viewport.hpp
@@ -20,18 +20,38 @@ enum class ForceCentering
 
 R get_map_view_area();
 
-// NOTE: This function does not necessarily center the map on the given position
-// (unless force_centering is true). It only guarantees that the position will
-// be visible in the viewport.
+// Centers the view on the given position. force_centering additionally ends
+// any manual pan.
+//
+// The camera GLIDES there: the view is drawn where the camera currently is,
+// not where it is going (see io::offset_map_follow). Use cut_to for a jump.
 void show(
         const P& map_pos,
         ForceCentering force_centering = ForceCentering::no);
 
+// Centers on the position at once, no glide - a new level, a teleport,
+// placing the aim reticle.
+void cut_to(const P& map_pos);
+
+// Brings the drawn view origin up to a gliding camera, same target. Driven
+// by the render loop, since not every state re-centers the view every frame
+// (the aim marker only does so when its position leaves the view).
+void advance_camera();
+
+// Drops any camera lag where the view is drawn - the camera stops where it
+// stands. For when something else takes the map over (manual panning, the
+// interface changing hands).
+void cut_camera();
+
+// Whether the camera has glided into another cell than the map display was
+// drawn with, so the map has to be redrawn at the new origin.
+bool is_camera_redraw_needed();
+
 // Manual camera panning (dragging on touch devices - the "look"
 // interaction, see center_map_pos). Offsets the view by a number of map
 // cells, and suppresses automatic re-centering on the player until the
-// player moves (see should_auto_center), or until a forced centering
-// occurs (e.g. aiming at a position outside the view, or a new level).
+// player moves (see should_auto_center), or until a forced centering or a
+// cut occurs (e.g. aiming at a position outside the view, or a new level).
 //
 // The pan limits allow bringing ANY map cell to the view's centering point
 // - the view may scroll beyond the map edges (showing blackness); the only
@@ -49,17 +69,17 @@ P center_map_pos();
 // Whether the view should currently follow the player. Returns true normally.
 // While a manual pan is active it returns false - until the player has moved
 // from the position where the pan began, at which point the pan is dropped
-// and the camera snaps back to the player (returning true again).
+// and the camera glides back to the player (returning true again).
 bool should_auto_center();
 
 // Immediately drops any active manual pan - the camera follows the player
 // again from the next draw (e.g. when the side panel changes sides, the
-// map snaps back to the player as part of the slide animation).
+// map glides back to the player alongside the slide animation).
 void end_pan();
 
-// Drops any active manual pan AND snaps the camera back to centered on
-// the player - looking around is over (see game_commands::handle: any
-// action other than describing the pinned cell ends drag-to-look)
+// Drops any active manual pan AND glides back to centered on the player -
+// looking around is over (see game_commands::handle: any action other than
+// describing the pinned cell ends drag-to-look)
 void end_pan_and_center_on_player();
 
 // The current view origin (map position of the top left view cell)

--- a/src/action_bar.cpp
+++ b/src/action_bar.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/action_list_state.cpp
+++ b/src/action_list_state.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/actions_config.cpp
+++ b/src/actions_config.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/actor_hit.cpp
+++ b/src/actor_hit.cpp
@@ -32,6 +32,7 @@
 #include "property_factory.hpp"
 #include "property_handler.hpp"
 #include "random.hpp"
+#include "screen_shake.hpp"
 #include "sound.hpp"
 #include "terrain.hpp"
 #include "terrain_data.hpp"
@@ -385,6 +386,19 @@ static void on_player_hit(
 // -----------------------------------------------------------------------------
 namespace actor
 {
+static void run_hit_map_shake(
+        const Actor& defender,
+        const int dmg,
+        Actor* const attacker)
+{
+        if (is_player(&defender)) {
+                screen_shake::on_player_damaged(dmg, max_hp(defender));
+        }
+        else if (is_player(attacker) && can_player_see_actor(defender)) {
+                screen_shake::on_player_blow();
+        }
+}
+
 void hit(
         Actor& actor,
         int dmg,
@@ -448,6 +462,8 @@ void hit(
                         }
                 }
         }
+
+        run_hit_map_shake(actor, dmg, attacker);
 
         if (is_player(&actor)) {
                 on_player_hit(dmg, dmg_type, allow_wound);

--- a/src/bash.cpp
+++ b/src/bash.cpp
@@ -38,6 +38,7 @@
 #include "property_handler.hpp"
 #include "query.hpp"
 #include "random.hpp"
+#include "screen_shake.hpp"
 #include "state.hpp"
 #include "terrain.hpp"
 #include "terrain_data.hpp"
@@ -338,6 +339,9 @@ void attack_terrain(const P& att_pos, const item::Item& wpn)
 {
         io::flash_at(att_pos, colors::gray());
 
+        // Whether the door gives or holds, the blow landed
+        screen_shake::on_player_blow();
+
         terrain::Terrain* const terrain = map::g_terrain.at(att_pos);
 
         print_player_attack_terrain_msg(*terrain, att_pos, wpn);
@@ -453,6 +457,8 @@ actor::Actor* get_corpse_to_bash_at(const P& pos)
 void do_fake_attack_on_unseen_terrain(const P& pos, const item::Item& wpn)
 {
         io::flash_at(pos, colors::gray());
+
+        screen_shake::on_player_blow();
 
         print_player_attack_unseen_terrain_msg(wpn);
 

--- a/src/context_pins.cpp
+++ b/src/context_pins.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/death_cinematic.cpp
+++ b/src/death_cinematic.cpp
@@ -1,0 +1,232 @@
+// =============================================================================
+// Copyright Werewolf Camp
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// =============================================================================
+
+#include "death_cinematic.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "SDL_timer.h"
+#include "actor.hpp"
+#include "colors.hpp"
+#include "config.hpp"
+#include "easing.hpp"
+#include "io.hpp"
+#include "io_display.hpp"
+#include "map.hpp"
+#include "msg_log.hpp"
+#include "panel.hpp"
+#include "pos.hpp"
+#include "rect.hpp"
+#include "state.hpp"
+#include "viewport.hpp"
+
+// -----------------------------------------------------------------------------
+// Private
+// -----------------------------------------------------------------------------
+// Tracks on one timeline, deliberately overlapping: the interface leaves
+// first, and the map is fully red long before the vignette has closed. The
+// vignette runs the zoom's length, so the two always land together.
+static const uint32_t s_red_duration_ms = 5000;
+static const uint32_t s_zoom_duration_ms = 9000;
+
+// A tap swaps the vignette for this, from the moment it is tapped
+static const uint32_t s_skip_fade_ms = 3000;
+
+// The interface leaves at once - it is not part of the shot
+static const uint32_t s_ui_exit_ms = 700;
+
+// Roughly 60 frames per second - a full redraw per step
+static const uint32_t s_step_delay_ms = 16;
+
+static const float s_zoom_end = 1.7f;
+
+// Slides the stats panel, the movement pad and the action bar off by their
+// nearest edge. The log stays - the death message is read from it.
+static void set_ui_exit_progress(const float progress)
+{
+        const R screen_rect = io::panel_logical_px_rect(Panel::screen);
+
+        const int travel_x =
+                (int)std::lround((float)screen_rect.w() * progress);
+
+        const int travel_y =
+                (int)std::lround((float)screen_rect.h() * progress);
+
+        // The pad sits on the edge opposite the stats panel, so handedness
+        // alone decides which way each of them leaves
+        const bool is_side_left = config::is_side_panel_left();
+
+        io::set_display_px_offset(
+                io::Display::side,
+                {is_side_left ? -travel_x : travel_x, 0});
+
+        io::set_display_px_offset(
+                io::Display::dpad,
+                {is_side_left ? travel_x : -travel_x, 0});
+
+        io::set_display_px_offset(io::Display::bar, {0, travel_y});
+}
+
+// How far into a track, 0 to 1. Tracks that have not started yet sit at 0,
+// finished ones at 1.
+static float track_progress(
+        const uint32_t elapsed_ms,
+        const uint32_t start_ms,
+        const uint32_t duration_ms)
+{
+        if (elapsed_ms <= start_ms) {
+                return 0.0f;
+        }
+
+        if (duration_ms == 0) {
+                return 1.0f;
+        }
+
+        return std::min(
+                1.0f,
+                (float)(elapsed_ms - start_ms) / (float)duration_ms);
+}
+
+// Where the player sits in the map panel, in logical pixels
+static P player_center_px()
+{
+        const P view_pos = viewport::to_view_pos(map::g_player->m_pos);
+
+        const int cell_w = config::map_cell_px_w();
+        const int cell_h = config::map_cell_px_h();
+
+        return {
+                (view_pos.x * cell_w) + (cell_w / 2),
+                (view_pos.y * cell_h) + (cell_h / 2)};
+}
+
+// The tracks that run whichever way the sequence ends
+static void apply_tracks(const uint32_t elapsed_ms)
+{
+        set_ui_exit_progress(
+                ease::out(track_progress(elapsed_ms, 0, s_ui_exit_ms)));
+
+        const float zoom =
+                1.0f +
+                ((s_zoom_end - 1.0f) *
+                 ease::in(track_progress(elapsed_ms, 0, s_zoom_duration_ms)));
+
+        io::set_map_zoom(zoom, player_center_px());
+
+        // Green and blue drain away, leaving the red channel at full
+        // strength - so the map reddens rather than darkening
+        const auto channel =
+                (uint8_t)std::lround(
+                        255.0f *
+                        (1.0f -
+                         track_progress(elapsed_ms, 0, s_red_duration_ms)));
+
+        io::set_map_tint(Color(255, channel, channel));
+}
+
+// How the sequence goes dark: the vignette closes on the player over the
+// whole zoom, unless a tap has swapped it for a flat fade from wherever it
+// had closed to.
+static void draw_ending(
+        const uint32_t elapsed_ms,
+        const uint32_t fade_start_ms)
+{
+        if (fade_start_ms == 0) {
+                io::set_map_vignette(
+                        player_center_px(),
+                        1.0f -
+                                ease::out(
+                                        track_progress(
+                                                elapsed_ms,
+                                                0,
+                                                s_zoom_duration_ms)));
+
+                return;
+        }
+
+        const float fade_t =
+                track_progress(elapsed_ms, fade_start_ms, s_skip_fade_ms);
+
+        io::set_display(io::Display::overlay);
+
+        io::draw_rectangle_filled(
+                io::panel_logical_px_rect(Panel::screen),
+                colors::black(),
+                (uint8_t)std::lround(255.0f * fade_t));
+}
+
+// -----------------------------------------------------------------------------
+// death_cinematic
+// -----------------------------------------------------------------------------
+namespace death_cinematic
+{
+void run()
+{
+        if (config::is_bot_playing() || !map::g_player) {
+                return;
+        }
+
+        const uint32_t start_ms = SDL_GetTicks();
+
+        // The death message carries the prompt's hint from the first frame,
+        // but is not allowed to wait on it - the tap is read here instead
+        msg_log::set_more_prompt_hint_shown(true);
+
+        // Nothing is taking a column any more, so the camera glides the
+        // player to dead center as the panels leave
+        viewport::set_center_bias_enabled(false);
+
+        // Zero until a tap cuts the sequence short - the vignette carries it
+        // to black on its own otherwise
+        uint32_t fade_start_ms = 0;
+
+        while (true) {
+                const uint32_t elapsed_ms = SDL_GetTicks() - start_ms;
+
+                if ((fade_start_ms == 0) && io::poll_any_input()) {
+                        fade_start_ms = std::max(1u, elapsed_ms);
+                }
+
+                const bool is_done =
+                        (fade_start_ms > 0)
+                        ? (elapsed_ms >= (fade_start_ms + s_skip_fade_ms))
+                        : (elapsed_ms >= s_zoom_duration_ms);
+
+                apply_tracks(elapsed_ms);
+
+                states::draw();
+
+                draw_ending(elapsed_ms, fade_start_ms);
+
+                io::update_screen();
+
+                if (is_done) {
+                        break;
+                }
+
+                io::sleep(s_step_delay_ms);
+        }
+
+        msg_log::set_more_prompt_hint_shown(false);
+
+        io::clear_input();
+}
+
+void reset()
+{
+        io::set_map_zoom(1.0f, {0, 0});
+
+        io::clear_map_tint();
+
+        io::clear_map_vignette();
+
+        io::reset_display_px_offsets();
+
+        viewport::set_center_bias_enabled(true);
+}
+
+}  // namespace death_cinematic

--- a/src/descr_column.cpp
+++ b/src/descr_column.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/dpad.cpp
+++ b/src/dpad.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -24,7 +24,6 @@
 #include "global.hpp"
 #include "inventory.hpp"
 #include "io.hpp"
-#include "io_display.hpp"
 #include "item.hpp"
 #include "item_data.hpp"
 #include "item_explosive.hpp"
@@ -40,6 +39,7 @@
 #include "property_factory.hpp"
 #include "property_handler.hpp"
 #include "random.hpp"
+#include "screen_shake.hpp"
 #include "sound.hpp"
 #include "state.hpp"
 #include "terrain.hpp"
@@ -138,14 +138,6 @@ static std::vector<std::vector<P>> positions_reached(
         return out;
 }
 
-// How far the map is thrown by a blast: a third of a cell, so that it
-// reads as a jolt at any cell size, and never more than the map display
-// can show (one cell of overscan, see io_display)
-static int map_shake_amplitude_px()
-{
-        return std::max(2, config::map_cell_px_h() / 3);
-}
-
 static void draw(
         const std::vector<std::vector<P>>& pos_lists,
         const Array2<bool>& blocked,
@@ -204,8 +196,7 @@ static void draw(
                                 // it), so the shake costs no time of its
                                 // own - and it settles at about the same
                                 // moment the last blast frame clears.
-                                io::start_map_shake(
-                                        map_shake_amplitude_px(),
+                                screen_shake::on_explosion(
                                         (uint32_t)config::delay_explosion());
                         }
 

--- a/src/fade.cpp
+++ b/src/fade.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -444,9 +444,7 @@ void GameState::on_start()
 
                 minimap::clear();
 
-                viewport::show(
-                        map::g_player->m_pos,
-                        viewport::ForceCentering::yes);
+                viewport::cut_to(map::g_player->m_pos);
 
                 map::update_vision();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -28,6 +28,7 @@
 #include "config.hpp"
 #include "context_pins.hpp"
 #include "create_character.hpp"
+#include "death_cinematic.hpp"
 #include "debug.hpp"
 #include "draw_health_bars.hpp"
 #include "draw_map.hpp"
@@ -71,9 +72,6 @@ static int s_xp_pct = 0;
 static int s_xp_accum = 0;
 static TimeData s_start_time;
 static IsWin s_is_win = IsWin::no;
-
-static int s_death_overlay_tint = 0;
-static int s_death_overlay_last_update_cycle = 0;
 
 static std::vector<HistoryEvent> s_history_events;
 
@@ -131,9 +129,6 @@ void init()
         s_xp_pct = 0;
         s_xp_accum = 0;
         s_is_win = IsWin::no;
-
-        s_death_overlay_tint = 100;
-        s_death_overlay_last_update_cycle = 0;
 
         s_history_events.clear();
 }
@@ -584,25 +579,6 @@ void GameState::draw_map_display()
         if (config::display_health_bars()) {
                 draw_health_bars();
         }
-
-        // If the player is dead, fade to red.
-        if (!actor::is_alive(*map::g_player)) {
-                const int current_cycle = io::graphics_cycle_nr(io::GraphicsCycle::fast);
-
-                if (current_cycle > s_death_overlay_last_update_cycle) {
-                        s_death_overlay_last_update_cycle = current_cycle;
-
-                        const int min_tint = 30;
-
-                        s_death_overlay_tint = std::max(min_tint, s_death_overlay_tint - 10);
-                }
-
-                io::set_display_for_panel(Panel::map);
-
-                io::draw_rectangle_filled_mod_blending(
-                        io::gui_to_px_rect(panels::area(Panel::map)),
-                        colors::red().tinted(s_death_overlay_tint));
-        }
 }
 
 void GameState::draw()
@@ -836,13 +812,19 @@ void GameState::update()
 
                 audio::play(audio::SfxId::death);
 
+                // Shown from the cinematic's first frame - it carries the
+                // prompt's hint, and reads the tap itself
                 msg_log::add(
                         "-I AM DEAD!-",
                         colors::msg_bad(),
                         MsgInterruptPlayer::no,
-                        MorePromptOnMsg::yes);
+                        MorePromptOnMsg::no);
+
+                death_cinematic::run();
 
                 saving::erase_save();
+
+                death_cinematic::reset();
 
                 states::pop();
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -419,9 +419,9 @@ static SDL_Renderer* create_renderer()
         TRACE_FUNC_BEGIN;
 
         // Vsync paces every present, which is what makes the camera follow
-        // advance in even steps, and keeps the idle render loop from
-        // compositing hundreds of frames a second. No other flags: SDL picks
-        // the best driver it can, which on a phone means the accelerated one.
+        // advance in even steps, and caps the render loops. It blocks until
+        // vblank - io::sleep takes that off the delay that follows, so a
+        // step is not charged for the wait twice.
         SDL_Renderer* renderer =
                 SDL_CreateRenderer(
                         io::g_sdl_window,
@@ -1204,22 +1204,40 @@ void sleep(const uint32_t duration)
         if ((duration == 0) || config::is_bot_playing()) {
                 return;
         }
-        else if (duration == 1) {
-                SDL_Delay(duration);
+
+        // The animation loops draw, present, then wait - and with vsync the
+        // present already blocked until vblank, so the full delay on top
+        // would charge for that twice. A delay NOT preceded by a blocking
+        // present has nothing to take, so a deliberate pause is left whole.
+        const uint32_t blocked_ms =
+                std::min(take_last_present_block_ms(), duration);
+
+        const uint32_t remaining = duration - blocked_ms;
+
+        if (remaining == 0) {
+                return;
         }
-        else {
-                // Duration longer than 1 ms
-                const auto wait_until = SDL_GetTicks() + duration;
 
-                while (SDL_GetTicks() < wait_until) {
-                        SDL_PumpEvents();
+        if (remaining == 1) {
+                SDL_Delay(remaining);
 
-                        // The map shake and the camera follow animate through
-                        // any wait - notably the blast animation's own delay
-                        if (step_map_animations()) {
-                                update_screen();
-                        }
+                return;
+        }
+
+        const auto wait_until = SDL_GetTicks() + remaining;
+
+        while (SDL_GetTicks() < wait_until) {
+                SDL_PumpEvents();
+
+                // The map shake and the camera follow animate through any
+                // wait - notably the blast animation's own delay
+                if (step_map_animations()) {
+                        update_screen();
                 }
+
+                // Yield rather than spin - the steps above are gated to a
+                // frame at most, so nothing here needs a finer cadence
+                SDL_Delay(1);
         }
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -418,10 +418,24 @@ static SDL_Renderer* create_renderer()
 {
         TRACE_FUNC_BEGIN;
 
-        // No renderer flags - SDL picks the best driver it can, which on a
-        // phone means the accelerated one
-        SDL_Renderer* const renderer =
-                SDL_CreateRenderer(io::g_sdl_window, -1, 0U);
+        // Vsync paces every present, which is what makes the camera follow
+        // advance in even steps, and keeps the idle render loop from
+        // compositing hundreds of frames a second. No other flags: SDL picks
+        // the best driver it can, which on a phone means the accelerated one.
+        SDL_Renderer* renderer =
+                SDL_CreateRenderer(
+                        io::g_sdl_window,
+                        -1,
+                        SDL_RENDERER_PRESENTVSYNC);
+
+        if (!renderer) {
+                TRACE
+                        << "No vsync capable renderer, retrying without: "
+                        << SDL_GetError()
+                        << std::endl;
+
+                renderer = SDL_CreateRenderer(io::g_sdl_window, -1, 0U);
+        }
 
         if (!renderer) {
                 TRACE_ERROR_RELEASE
@@ -1200,12 +1214,9 @@ void sleep(const uint32_t duration)
                 while (SDL_GetTicks() < wait_until) {
                         SDL_PumpEvents();
 
-                        // A map shake animates through any wait - notably
-                        // the blast animation's own delay, which is exactly
-                        // when an explosion should be shaking the ground.
-                        // Stepping it is a composite and a present, the
-                        // drawn frame is reused as it stands.
-                        if (step_map_shake()) {
+                        // The map shake and the camera follow animate through
+                        // any wait - notably the blast animation's own delay
+                        if (step_map_animations()) {
                                 update_screen();
                         }
                 }

--- a/src/io_display.cpp
+++ b/src/io_display.cpp
@@ -48,20 +48,126 @@ static P map_overscan_px()
 // Shake offset of the map (see start_map_shake), added to the scroll offset
 static P s_map_shake_px = {0, 0};
 
-// Where the composite samples the map texture: the camera offset and the
-// shake together. The overscan is all the displacement there is drawn
-// content for - beyond it the copy would sample outside the texture.
+// How far behind its drawn framing the camera is (see offset_map_follow),
+// in logical pixels. Floating point - rounding each step would stall the
+// last pixels of the ease.
+static float s_map_follow_px_x = 0.0f;
+static float s_map_follow_px_y = 0.0f;
+
+// Fraction of the remaining distance covered in one reference frame. The
+// alpha is rescaled from the real elapsed time, so the follow takes the same
+// time at any refresh rate.
+static const float s_map_follow_lerp = 0.18f;
+static const float s_map_follow_reference_frame_ms = 16.67f;
+
+// An exponential never arrives; below this the camera has caught up
+static const float s_map_follow_min_px = 0.5f;
+
+// Zero means the camera has just gone behind and the clock has not started
+static uint32_t s_map_follow_last_step_ms = 0;
+
+// Whole cells of the lag the map display was last drawn with
+static P s_map_follow_drawn_cells = {0, 0};
+
+// Whole cells of lag beyond the one cell the composite can carry
+static int follow_whole_cells(const float lag_px, const int cell_px)
+{
+        if (cell_px <= 0) {
+                return 0;
+        }
+
+        const float cell = (float)cell_px;
+
+        if (lag_px > cell) {
+                return (int)((lag_px - cell) / cell) + 1;
+        }
+
+        if (lag_px < -cell) {
+                return -((int)((-lag_px - cell) / cell) + 1);
+        }
+
+        return 0;
+}
+
+// Eases the camera toward its framing. Called once per present, from the
+// composite, so it advances through anything that puts frames on screen.
+static void step_map_follow()
+{
+        if (!io::is_map_follow_active()) {
+                s_map_follow_px_x = 0.0f;
+                s_map_follow_px_y = 0.0f;
+
+                s_map_follow_last_step_ms = 0;
+
+                return;
+        }
+
+        const uint32_t now_ms = SDL_GetTicks();
+
+        if (s_map_follow_last_step_ms == 0) {
+                // This present shows the player on its new cell with the map
+                // not yet caught up - the motion starts from the next one
+                s_map_follow_last_step_ms = now_ms;
+
+                return;
+        }
+
+        const uint32_t elapsed_ms = now_ms - s_map_follow_last_step_ms;
+
+        if (elapsed_ms == 0) {
+                // Leave the clock, so the time is not lost
+                return;
+        }
+
+        s_map_follow_last_step_ms = now_ms;
+
+        const float alpha =
+                1.0f -
+                std::pow(
+                        1.0f - s_map_follow_lerp,
+                        (float)elapsed_ms / s_map_follow_reference_frame_ms);
+
+        // A long stall saturates the alpha, putting the camera where it
+        // should have been by now
+        const float remaining = 1.0f - std::min(alpha, 1.0f);
+
+        s_map_follow_px_x *= remaining;
+        s_map_follow_px_y *= remaining;
+
+        if (!io::is_map_follow_active()) {
+                s_map_follow_px_x = 0.0f;
+                s_map_follow_px_y = 0.0f;
+
+                s_map_follow_last_step_ms = 0;
+        }
+}
+
+// Where the composite samples the map texture: the manual pan, the camera
+// follow and the shake together. The overscan is all the displacement there
+// is drawn content for - beyond it the copy would sample outside the
+// texture.
 static P map_src_offset_px()
 {
+        // One cell: both the overscan and the unit the drawn whole cells are
+        // counted in
         const auto overscan = map_overscan_px();
+
+        // Only what the drawn origin did not take on
+        const P follow(
+                (int)std::lround(
+                        s_map_follow_px_x -
+                        (float)(s_map_follow_drawn_cells.x * overscan.x)),
+                (int)std::lround(
+                        s_map_follow_px_y -
+                        (float)(s_map_follow_drawn_cells.y * overscan.y)));
 
         return {
                 std::clamp(
-                        s_map_scroll_px.x + s_map_shake_px.x,
+                        s_map_scroll_px.x + follow.x + s_map_shake_px.x,
                         -overscan.x,
                         overscan.x),
                 std::clamp(
-                        s_map_scroll_px.y + s_map_shake_px.y,
+                        s_map_scroll_px.y + follow.y + s_map_shake_px.y,
                         -overscan.y,
                         overscan.y)};
 }
@@ -387,6 +493,9 @@ void clear_display_textures()
 
 void composite_display_textures()
 {
+        // The camera advances per present, not per pass of one loop
+        step_map_follow();
+
         SDL_SetRenderTarget(g_sdl_renderer, nullptr);
 
         s_current_display = Display::END;
@@ -424,7 +533,7 @@ void composite_display_textures()
                         // The map is copied as a region: a map-panel sized
                         // window into the overscanned content, shifted by the
                         // sub-cell scroll offset (map panning, the camera
-                        // follow tween, and any shake)
+                        // follow, and any shake)
                         const auto overscan = map_overscan_px();
 
                         const auto scroll = map_src_offset_px();
@@ -531,111 +640,47 @@ void set_map_scroll_px_offset(const P& px_offset)
         s_map_scroll_px = px_offset;
 }
 
-P map_scroll_px_offset()
+void offset_map_follow(const P& px_offset)
 {
-        return s_map_scroll_px;
+        const bool was_settled = !io::is_map_follow_active();
+
+        s_map_follow_px_x += (float)px_offset.x;
+        s_map_follow_px_y += (float)px_offset.y;
+
+        if (was_settled) {
+                // Clock starts at the next present - see step_map_follow
+                s_map_follow_last_step_ms = 0;
+        }
 }
 
-// Camera follow tween state (see start_map_follow_tween)
-static P s_follow_tween_start_px(0, 0);
-static uint32_t s_follow_tween_start_ms = 0;
-static bool s_is_follow_tween_active = false;
-
-// Whether the clock has been started (see step_map_follow_tween)
-static bool s_is_follow_tween_running = false;
-
-static const uint32_t s_follow_tween_duration_ms = 90;
-
-void start_map_follow_tween(const P& px_offset)
+bool is_map_follow_active()
 {
-        s_follow_tween_start_px = px_offset;
-        s_is_follow_tween_active = true;
-
-        // NOTE: The clock is NOT started here - see step_map_follow_tween
-        s_is_follow_tween_running = false;
-
-        // The content starts out visually where it was before the
-        // viewport stepped, and eases to the new position
-        set_map_scroll_px_offset(px_offset);
+        return (std::fabs(s_map_follow_px_x) >= s_map_follow_min_px) ||
+                (std::fabs(s_map_follow_px_y) >= s_map_follow_min_px);
 }
 
-bool is_map_follow_tween_active()
+P map_follow_whole_cells()
 {
-        return s_is_follow_tween_active;
+        return {
+                follow_whole_cells(
+                        s_map_follow_px_x,
+                        config::map_cell_px_w()),
+                follow_whole_cells(
+                        s_map_follow_px_y,
+                        config::map_cell_px_h())};
 }
 
-bool step_map_follow_tween()
+void set_map_follow_drawn_whole_cells(const P& cells)
 {
-        if (!s_is_follow_tween_active) {
-                return false;
-        }
-
-        if (!s_is_follow_tween_running) {
-                // The tween is STARTED where the camera moves - which is in
-                // the middle of a state draw - but it can only be STEPPED
-                // by the animation loop (see io::read_input). Timing it
-                // from the start would spend the tween on everything in
-                // between: the rest of that frame's drawing (the whole map
-                // is redrawn there), its present, and the remaining turn
-                // processing. On a slow device that is longer than the
-                // tween itself, so the first step already found it expired,
-                // jumped the offset to zero and the camera appeared to snap
-                // - no intermediate frame was ever shown.
-                //
-                // So the clock starts at the first step instead. The frame
-                // showing the start offset (the player on its new cell, the
-                // map not yet caught up) is already on screen by then.
-                s_is_follow_tween_running = true;
-
-                s_follow_tween_start_ms = SDL_GetTicks();
-
-                return false;
-        }
-
-        const uint32_t elapsed_ms =
-                SDL_GetTicks() - s_follow_tween_start_ms;
-
-        P new_offset(0, 0);
-
-        if (elapsed_ms >= s_follow_tween_duration_ms) {
-                s_is_follow_tween_active = false;
-        }
-        else {
-                const float t =
-                        (float)elapsed_ms /
-                        (float)s_follow_tween_duration_ms;
-
-                const float u = 1.0f - t;
-
-                const float remaining = u * u * u;  // Cubic.out
-
-                new_offset.set(
-                        (int)std::lround(
-                                (float)s_follow_tween_start_px.x *
-                                remaining),
-                        (int)std::lround(
-                                (float)s_follow_tween_start_px.y *
-                                remaining));
-        }
-
-        if (new_offset == s_map_scroll_px) {
-                return false;
-        }
-
-        set_map_scroll_px_offset(new_offset);
-
-        return true;
+        s_map_follow_drawn_cells = cells;
 }
 
-void cancel_map_follow_tween()
+void cancel_map_follow()
 {
-        if (!s_is_follow_tween_active) {
-                return;
-        }
+        s_map_follow_px_x = 0.0f;
+        s_map_follow_px_y = 0.0f;
 
-        s_is_follow_tween_active = false;
-
-        set_map_scroll_px_offset({0, 0});
+        s_map_follow_last_step_ms = 0;
 }
 
 // -----------------------------------------------------------------------------
@@ -647,9 +692,9 @@ static uint32_t s_shake_start_ms = 0;
 static bool s_is_shake_active = false;
 static bool s_is_shake_running = false;
 
-// The shake is stepped from tight loops (io::sleep spins, and the input
-// loop iterates every millisecond) - it advances at most this often, so
-// that a shake costs a bounded number of composites
+// The shake is stepped from tight loops (see step_map_animations) - it
+// advances at most this often, so a shake costs a bounded number of
+// composites
 static const uint32_t s_shake_step_interval_ms = 12;
 
 static uint32_t s_shake_last_step_ms = 0;
@@ -664,7 +709,7 @@ void start_map_shake(const int amplitude_px, const uint32_t duration_ms)
         s_shake_duration_ms = duration_ms;
         s_is_shake_active = true;
 
-        // NOTE: As with the follow tween, the clock starts at the first
+        // NOTE: As with the camera follow, the clock starts at the first
         // step - not here, where the caller may still have drawing to do
         s_is_shake_running = false;
 }
@@ -674,7 +719,7 @@ bool is_map_shake_active()
         return s_is_shake_active;
 }
 
-bool step_map_shake()
+static bool step_map_shake()
 {
         if (!s_is_shake_active) {
                 return false;
@@ -730,6 +775,34 @@ bool step_map_shake()
         return true;
 }
 
+bool step_map_animations()
+{
+        // Stepped here as well as in the composite, so the camera is up to
+        // date before the redraw decision below. The ease is time based, so
+        // stepping twice in a pass is not double counted.
+        step_map_follow();
+
+        const bool did_step_shake = step_map_shake();
+
+        const bool is_following = is_map_follow_active();
+
+        if (!is_following && !did_step_shake) {
+                return false;
+        }
+
+        // The composite carries at most one cell - past that the drawn view
+        // origin has to move, which means redrawing the map. A state with no
+        // map display has no camera either, so a refused redraw needs no
+        // fallback.
+        if (is_following && viewport::is_camera_redraw_needed()) {
+                viewport::advance_camera();
+
+                states::draw_map_display();
+        }
+
+        return true;
+}
+
 P window_px_to_logical_px(const P& window_px)
 {
         const auto p = window_px - g_rendering_px_offset;
@@ -774,11 +847,15 @@ void run_side_panel_slide_animation()
 
         dpad::mirror_placement();
 
-        // A manually panned map snaps back to the player as part of the
+        // A manually panned map glides back to the player alongside the
         // slide animation
         viewport::end_pan();
 
         s_map_scroll_px = {0, 0};
+
+        // The framing itself is moving here - the camera has nothing to
+        // catch up to
+        viewport::cut_camera();
 
         // Flip the layout, and redraw the game into the display textures at
         // the new positions (the animation below only offsets the compositing

--- a/src/io_display.cpp
+++ b/src/io_display.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================
@@ -10,13 +10,16 @@
 #include <cmath>
 #include <cstddef>
 #include <ostream>
+#include <vector>
 
 #include "SDL_render.h"
 #include "SDL_timer.h"
+#include "colors.hpp"
 #include "config.hpp"
 #include "context_pins.hpp"
 #include "debug.hpp"
 #include "dpad.hpp"
+#include "easing.hpp"
 #include "io.hpp"
 #include "io_internal.hpp"
 #include "panel.hpp"
@@ -40,13 +43,49 @@ static R s_display_px_rects[(size_t)io::Display::END] = {};
 // the composited map window always has content when sliding between cells.
 static P s_map_scroll_px = {0, 0};
 
+// The map texture reserves one cell for the camera follow plus this much
+// for a shake, so that a shake still has room to move while the camera is
+// at full lag - which is exactly when the player takes a hit
 static P map_overscan_px()
 {
-        return {config::map_cell_px_w(), config::map_cell_px_h()};
+        const int shake = io::max_map_shake_px();
+
+        return {
+                config::map_cell_px_w() + shake,
+                config::map_cell_px_h() + shake};
 }
 
 // Shake offset of the map (see start_map_shake), added to the scroll offset
 static P s_map_shake_px = {0, 0};
+
+// Map magnification and the point it is centered on (see set_map_zoom)
+static float s_map_zoom = 1.0f;
+static P s_map_zoom_center_px = {0, 0};
+
+// Radial gradient for the vignette, built once on first use (see
+// set_map_vignette). Small - it is always stretched, and a soft ramp
+// survives that with linear filtering.
+static SDL_Texture* s_vignette_texture = nullptr;
+static const int s_vignette_texture_px = 512;
+
+// How much of the gradient's radius is fully clear before it starts to
+// darken. Small, so the ramp spans nearly the whole radius and the darkness
+// has no edge to it.
+static const float s_vignette_clear_frac = 0.05f;
+
+// Spread of the gradient at full open, as a fraction of the screen's width
+// plus height - large enough that none of its darkening is on screen yet
+static const float s_vignette_open_span = 1.6f;
+
+// Where the vignette is closing to, and how far (see set_map_vignette)
+static P s_vignette_center_px = {0, 0};
+static float s_vignette_open_frac = 1.0f;
+
+// Multiplied over the map as it is composited (see set_map_tint). NOT
+// initialized from colors::white() - the named colors load from xml long
+// after a file scope static is constructed, so that would capture an
+// unloaded (black) color.
+static Color s_map_tint = Color(255, 255, 255);
 
 // How far behind its drawn framing the camera is (see offset_map_follow),
 // in logical pixels. Floating point - rounding each step would stall the
@@ -142,24 +181,155 @@ static void step_map_follow()
         }
 }
 
+// A soft radial ramp - transparent in the middle, opaque black at the rim.
+// Stretched to whatever size the vignette needs, so one small texture
+// serves every stage of the close.
+static SDL_Texture* vignette_texture()
+{
+        if (s_vignette_texture) {
+                return s_vignette_texture;
+        }
+
+        const int dims = s_vignette_texture_px;
+
+        std::vector<uint32_t> pixels((size_t)(dims * dims));
+
+        const float half = (float)dims / 2.0f;
+
+        for (int y = 0; y < dims; ++y) {
+                for (int x = 0; x < dims; ++x) {
+                        const float dx = ((float)x + 0.5f - half) / half;
+                        const float dy = ((float)y + 0.5f - half) / half;
+
+                        const float dist = std::sqrt((dx * dx) + (dy * dy));
+
+                        const float t =
+                                std::clamp(
+                                        (dist - s_vignette_clear_frac) /
+                                                (1.0f - s_vignette_clear_frac),
+                                        0.0f,
+                                        1.0f);
+
+                        // Smoothstep - soft at both ends, so the darkness
+                        // arrives without an edge anywhere along the ramp
+                        const float a = t * t * (3.0f - (2.0f * t));
+
+                        const auto alpha = (uint32_t)std::lround(a * 255.0f);
+
+                        pixels[(size_t)((y * dims) + x)] = (alpha << 24);
+                }
+        }
+
+        s_vignette_texture =
+                SDL_CreateTexture(
+                        io::g_sdl_renderer,
+                        SDL_PIXELFORMAT_ARGB8888,
+                        SDL_TEXTUREACCESS_STATIC,
+                        dims,
+                        dims);
+
+        if (!s_vignette_texture) {
+                TRACE_ERROR_RELEASE
+                        << "Failed to create vignette texture: "
+                        << SDL_GetError()
+                        << std::endl;
+
+                return nullptr;
+        }
+
+        SDL_UpdateTexture(
+                s_vignette_texture,
+                nullptr,
+                pixels.data(),
+                dims * (int)sizeof(uint32_t));
+
+        SDL_SetTextureBlendMode(s_vignette_texture, SDL_BLENDMODE_BLEND);
+
+        SDL_SetTextureScaleMode(s_vignette_texture, SDL_ScaleModeLinear);
+
+        return s_vignette_texture;
+}
+
+// Darkness closing on the vignette's center, drawn straight onto the window
+// over the map's composited area (see set_map_vignette). Window pixels - the
+// map's destination rectangle and the video scale, not logical coordinates.
+static void draw_map_vignette(const SDL_Rect& map_rect, const int scale)
+{
+        if (s_vignette_open_frac >= 1.0f) {
+                return;
+        }
+
+        auto* const texture = vignette_texture();
+
+        if (!texture) {
+                return;
+        }
+
+        // Fully open spreads the gradient far beyond the map, so only its
+        // clear middle is on show; closing shrinks it onto the center point
+        const float span =
+                (float)(map_rect.w + map_rect.h) *
+                s_vignette_open_span *
+                s_vignette_open_frac;
+
+        const int half = (int)std::lround(span / 2.0f);
+
+        const int center_x = map_rect.x + (s_vignette_center_px.x * scale);
+        const int center_y = map_rect.y + (s_vignette_center_px.y * scale);
+
+        const SDL_Rect gradient {
+                center_x - half,
+                center_y - half,
+                half * 2,
+                half * 2};
+
+        // Everything the gradient does not reach is past its rim, i.e.
+        // solid black. Four bands rather than a full screen blend beneath
+        // the gradient.
+        SDL_SetRenderDrawColor(io::g_sdl_renderer, 0U, 0U, 0U, 255U);
+
+        const int gradient_x1 = gradient.x + gradient.w;
+        const int gradient_y1 = gradient.y + gradient.h;
+
+        const int map_x1 = map_rect.x + map_rect.w;
+        const int map_y1 = map_rect.y + map_rect.h;
+
+        const int band_y0 = std::max(map_rect.y, gradient.y);
+        const int band_y1 = std::min(map_y1, gradient_y1);
+
+        const SDL_Rect bands[] {
+                {map_rect.x, map_rect.y, map_rect.w, gradient.y - map_rect.y},
+                {map_rect.x, gradient_y1, map_rect.w, map_y1 - gradient_y1},
+                {map_rect.x, band_y0, gradient.x - map_rect.x, band_y1 - band_y0},
+                {gradient_x1, band_y0, map_x1 - gradient_x1, band_y1 - band_y0}};
+
+        for (const auto& band : bands) {
+                if ((band.w > 0) && (band.h > 0)) {
+                        SDL_RenderFillRect(io::g_sdl_renderer, &band);
+                }
+        }
+
+        SDL_RenderCopy(io::g_sdl_renderer, texture, nullptr, &gradient);
+}
+
 // Where the composite samples the map texture: the manual pan, the camera
 // follow and the shake together. The overscan is all the displacement there
 // is drawn content for - beyond it the copy would sample outside the
 // texture.
 static P map_src_offset_px()
 {
-        // One cell: both the overscan and the unit the drawn whole cells are
-        // counted in
         const auto overscan = map_overscan_px();
 
         // Only what the drawn origin did not take on
         const P follow(
                 (int)std::lround(
                         s_map_follow_px_x -
-                        (float)(s_map_follow_drawn_cells.x * overscan.x)),
+                        (float)(s_map_follow_drawn_cells.x *
+                                config::map_cell_px_w())),
                 (int)std::lround(
                         s_map_follow_px_y -
-                        (float)(s_map_follow_drawn_cells.y * overscan.y)));
+                        (float)(s_map_follow_drawn_cells.y *
+                                config::map_cell_px_h())));
 
         return {
                 std::clamp(
@@ -236,13 +406,6 @@ static R display_logical_px_rect(const io::Display display)
         }
 
         return io::panel_logical_px_rect(Panel::screen);
-}
-
-static float ease_cubic_out(const float t)
-{
-        const float u = 1.0f - t;
-
-        return 1.0f - (u * u * u);
 }
 
 // -----------------------------------------------------------------------------
@@ -388,6 +551,12 @@ void init_displays()
 
 void cleanup_displays()
 {
+        if (s_vignette_texture) {
+                SDL_DestroyTexture(s_vignette_texture);
+
+                s_vignette_texture = nullptr;
+        }
+
         for (auto*& texture : s_display_textures) {
                 if (texture) {
                         SDL_DestroyTexture(texture);
@@ -538,11 +707,34 @@ void composite_display_textures()
 
                         const auto scroll = map_src_offset_px();
 
+                        // Zooming samples a smaller region into the same
+                        // destination. The centering point must land where it
+                        // did unzoomed, which is what it is offset by here.
+                        const int src_w =
+                                (int)std::lround(
+                                        (float)display_rect.w() / s_map_zoom);
+
+                        const int src_h =
+                                (int)std::lround(
+                                        (float)display_rect.h() / s_map_zoom);
+
+                        const int zoom_off_x =
+                                s_map_zoom_center_px.x -
+                                (int)std::lround(
+                                        (float)s_map_zoom_center_px.x /
+                                        s_map_zoom);
+
+                        const int zoom_off_y =
+                                s_map_zoom_center_px.y -
+                                (int)std::lround(
+                                        (float)s_map_zoom_center_px.y /
+                                        s_map_zoom);
+
                         const SDL_Rect src_rect {
-                                overscan.x + scroll.x,
-                                overscan.y + scroll.y,
-                                display_rect.w(),
-                                display_rect.h()};
+                                overscan.x + scroll.x + zoom_off_x,
+                                overscan.y + scroll.y + zoom_off_y,
+                                src_w,
+                                src_h};
 
                         const SDL_Rect dst_rect {
                                 offset.x + (display_rect.p0.x * scale),
@@ -550,11 +742,24 @@ void composite_display_textures()
                                 display_rect.w() * scale,
                                 display_rect.h() * scale};
 
+                        // Set every frame, so a tint can never outlive the
+                        // effect that asked for it
+                        SDL_SetTextureColorMod(
+                                texture,
+                                s_map_tint.r(),
+                                s_map_tint.g(),
+                                s_map_tint.b());
+
                         SDL_RenderCopy(
                                 g_sdl_renderer,
                                 texture,
                                 &src_rect,
                                 &dst_rect);
+
+                        // Straight onto the window, between the map and
+                        // everything composited after it - so the log and
+                        // the panels stay clear of the darkness
+                        draw_map_vignette(dst_rect, scale);
 
                         continue;
                 }
@@ -600,6 +805,35 @@ void composite_display_textures()
 
                 SDL_RenderCopy(g_sdl_renderer, texture, &src_rect, &dst_rect);
         }
+
+}
+
+void set_map_zoom(const float zoom, const P& center_px)
+{
+        s_map_zoom = std::max(1.0f, zoom);
+        s_map_zoom_center_px = center_px;
+}
+
+void set_map_vignette(const P& center_px, const float open_frac)
+{
+        s_vignette_center_px = center_px;
+
+        s_vignette_open_frac = std::clamp(open_frac, 0.0f, 1.0f);
+}
+
+void clear_map_vignette()
+{
+        s_vignette_open_frac = 1.0f;
+}
+
+void set_map_tint(const Color& color)
+{
+        s_map_tint = color;
+}
+
+void clear_map_tint()
+{
+        s_map_tint = Color(255, 255, 255);
 }
 
 void set_display_px_offset(const Display display, const P& px_offset)
@@ -697,7 +931,22 @@ static bool s_is_shake_running = false;
 // composites
 static const uint32_t s_shake_step_interval_ms = 12;
 
+// One oscillation per this much duration - slow enough that several frames
+// land within a cycle at 60 Hz, so the shake does not alias
+static const float s_shake_ms_per_cycle = 60.0f;
+
+// Minimum gap between frames presented for the camera follow (see
+// step_map_animations)
+static const uint32_t s_follow_frame_interval_ms = 15;
+
+static uint32_t s_follow_frame_last_ms = 0;
+
 static uint32_t s_shake_last_step_ms = 0;
+
+int max_map_shake_px()
+{
+        return std::max(4, (config::map_cell_px_h() * 2) / 3);
+}
 
 void start_map_shake(const int amplitude_px, const uint32_t duration_ms)
 {
@@ -705,7 +954,8 @@ void start_map_shake(const int amplitude_px, const uint32_t duration_ms)
                 return;
         }
 
-        s_shake_amplitude_px = amplitude_px;
+        s_shake_amplitude_px = std::min(amplitude_px, max_map_shake_px());
+
         s_shake_duration_ms = duration_ms;
         s_is_shake_active = true;
 
@@ -749,21 +999,31 @@ static bool step_map_shake()
                 const float t =
                         (float)elapsed_ms / (float)s_shake_duration_ms;
 
-                // Shaken hard at the blast, settling to nothing
+                // Shaken hard at the impact, settling to nothing
                 const float decay = (1.0f - t) * (1.0f - t);
+
+                // Whole oscillations, so the shake ends where it started -
+                // one fewer per axis, so it rattles instead of orbiting. A
+                // count fixed regardless of duration aliases on short
+                // shakes (see s_shake_ms_per_cycle).
+                const float cycles_x =
+                        std::max(
+                                1.0f,
+                                std::round(
+                                        (float)s_shake_duration_ms /
+                                        s_shake_ms_per_cycle));
+
+                const float cycles_y = std::max(1.0f, cycles_x - 1.0f);
+
+                const float two_pi = 2.0f * 3.14159265f;
 
                 const float amplitude = (float)s_shake_amplitude_px * decay;
 
-                // Whole oscillations, so the shake ends where it started -
-                // and a different count per axis, so that it rattles
-                // instead of orbiting
-                const float two_pi = 2.0f * 3.14159265f;
-
                 new_offset.set(
                         (int)std::lround(
-                                amplitude * std::sin(t * two_pi * 4.0f)),
+                                amplitude * std::sin(t * two_pi * cycles_x)),
                         (int)std::lround(
-                                amplitude * std::sin(t * two_pi * 3.0f)));
+                                amplitude * std::sin(t * two_pi * cycles_y)));
         }
 
         if (new_offset == s_map_shake_px) {
@@ -786,7 +1046,23 @@ bool step_map_animations()
 
         const bool is_following = is_map_follow_active();
 
-        if (!is_following && !did_step_shake) {
+        // A frame at most, however tightly the calling loop spins - the
+        // shake has its own interval, the follow would otherwise present as
+        // fast as the CPU allows
+        bool is_follow_frame_due = false;
+
+        if (is_following) {
+                const uint32_t now_ms = SDL_GetTicks();
+
+                if ((now_ms - s_follow_frame_last_ms) >=
+                    s_follow_frame_interval_ms) {
+                        s_follow_frame_last_ms = now_ms;
+
+                        is_follow_frame_due = true;
+                }
+        }
+
+        if (!is_follow_frame_due && !did_step_shake) {
                 return false;
         }
 
@@ -925,7 +1201,7 @@ void run_side_panel_slide_animation()
 
                 // The log and action bar displays slide to their new
                 // positions with Cubic.out easing
-                const float progress = ease_cubic_out(t);
+                const float progress = ease::cubic_out(t);
 
                 const float remaining = 1.0f - progress;
 
@@ -966,7 +1242,7 @@ void run_side_panel_slide_animation()
                         const float u =
                                 (t - exit_fraction) / (1.0f - exit_fraction);
 
-                        const float p = ease_cubic_out(u);
+                        const float p = ease::cubic_out(u);
 
                         side_off =
                                 (int)std::lround(

--- a/src/io_icons.cpp
+++ b/src/io_icons.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/io_input.cpp
+++ b/src/io_input.cpp
@@ -1797,6 +1797,30 @@ void clear_input()
         reset_touch_gesture();
 }
 
+bool poll_any_input()
+{
+        SDL_PumpEvents();
+
+        bool has_input = false;
+
+        SDL_Event event;
+
+        while (SDL_PollEvent(&event)) {
+                switch (event.type) {
+                case SDL_FINGERUP:
+                case SDL_KEYDOWN:
+                case SDL_MOUSEBUTTONUP:
+                        has_input = true;
+                        break;
+
+                default:
+                        break;
+                }
+        }
+
+        return has_input;
+}
+
 void haptic_feedback(const HapticFeedback kind)
 {
         android_haptic_tick(kind == HapticFeedback::press);

--- a/src/io_input.cpp
+++ b/src/io_input.cpp
@@ -1084,7 +1084,7 @@ static void handle_single_finger_motion()
                 // cells are transferred to the viewport underneath; the
                 // sub-cell remainder slides the composited map content. The
                 // pan is kept on release (settling on the nearest cell),
-                // and the camera snaps back to the player on any play
+                // and the camera glides back to the player on any play
                 // movement (see viewport::should_auto_center).
                 float latest_x = x;
                 float latest_y = y;
@@ -1199,7 +1199,7 @@ static void handle_single_finger_motion()
 
                                 // Manual panning takes over the map
                                 // scroll offset
-                                io::cancel_map_follow_tween();
+                                viewport::cut_camera();
 
                                 // The pan starts from the current finger
                                 // position - the travel so far is NOT
@@ -1403,7 +1403,7 @@ static void handle_finger_up_event()
                 // A provisional pan (targeting, no hold delay) that turned
                 // out to be a quick flick is a movement swipe after all -
                 // fall through to the classification below. The aiming
-                // state pops on the movement, which snaps the camera back,
+                // state pops on the movement, which brings the camera back,
                 // so the panning done meanwhile undoes itself.
                 if (!s_map_pan_provisional || !is_swipe) {
                         // The panned view is kept - ease the sub-cell
@@ -1726,11 +1726,10 @@ static void handle_polled_event()
 //
 // The loop used to delay exactly one millisecond per pass, i.e. it woke up a
 // thousand times a second to step a handful of timers whose shortest gate is
-// twelve milliseconds. On a desktop that is merely wasteful; on a battery
-// powered device it keeps the CPU out of its idle states permanently, and
-// the heat that produces is thermal throttling - which costs frame rate
-// everywhere else. Eight milliseconds is still ~120 passes a second, far
-// finer than any touch input can be perceived to lag.
+// twelve milliseconds. That keeps the CPU out of its idle states
+// permanently, and the heat it produces is thermal throttling - which costs
+// frame rate everywhere else. Eight milliseconds is still ~120 passes a
+// second, far finer than any touch input can be perceived to lag.
 static void idle_between_input_passes()
 {
         if (config::is_bot_playing()) {
@@ -1738,10 +1737,10 @@ static void idle_between_input_passes()
                 return;
         }
 
-        // A camera tween or a map shake is stepped from here, and moves the
-        // composited map every pass - those want a finer cadence
+        // The camera follow and the map shake move the composited map every
+        // pass - those want a finer cadence
         const bool is_map_animating =
-                io::is_map_follow_tween_active() ||
+                io::is_map_follow_active() ||
                 io::is_map_shake_active();
 
         SDL_Delay(is_map_animating ? 2U : 8U);
@@ -1894,12 +1893,11 @@ InputData read_input()
 
                 window_resized_delayed_draw();
 
-                // The camera follow tween and the map shake only move the
-                // composite offset of the map display - no state redraw
-                // needed
-                const bool did_step_follow_tween = step_map_follow_tween();
-
-                const bool did_step_shake = step_map_shake();
+                // The camera follow and the map shake move the composite
+                // offset of the map display, and the follow additionally
+                // redraws it whenever the camera glides past what the
+                // overscan can carry (see step_map_animations)
+                const bool is_map_animating = step_map_animations();
 
                 bool should_redraw_cycling = false;
 
@@ -1908,9 +1906,7 @@ InputData read_input()
                 // the whole state, which on a slow device takes longer than
                 // the animation itself and would leave it stepping instead
                 // of moving. Tile animation just waits those moments out.
-                if ((s_last_window_resize_ms == 0) &&
-                    !is_map_follow_tween_active() &&
-                    !is_map_shake_active()) {
+                if ((s_last_window_resize_ms == 0) && !is_map_animating) {
                         should_redraw_cycling = step_graphics_cycling();
                 }
 
@@ -1933,7 +1929,7 @@ InputData read_input()
 
                         update_screen();
                 }
-                else if (did_step_follow_tween || did_step_shake) {
+                else if (is_map_animating) {
                         update_screen();
                 }
 

--- a/src/io_primitives.cpp
+++ b/src/io_primitives.cpp
@@ -124,16 +124,4 @@ void draw_rectangles_filled(
                 (int)sdl_rects.size());
 }
 
-void draw_rectangle_filled_mod_blending(
-        R px_rect,
-        const Color& color,
-        uint8_t alpha)
-{
-        SDL_SetRenderDrawBlendMode(io::g_sdl_renderer, SDL_BLENDMODE_MOD);
-
-        draw_rectangle_filled(px_rect, color, alpha);
-
-        SDL_SetRenderDrawBlendMode(io::g_sdl_renderer, SDL_BLENDMODE_BLEND);
-}
-
 }  // namespace io

--- a/src/io_window.cpp
+++ b/src/io_window.cpp
@@ -227,6 +227,18 @@ P sdl_window_gui_dims()
 bool g_allow_render = false;
 #endif  // NDEBUG
 
+// How long the last present spent waiting for vblank (see update_screen)
+static uint32_t s_last_present_block_ms = 0;
+
+uint32_t take_last_present_block_ms()
+{
+        const uint32_t ms = s_last_present_block_ms;
+
+        s_last_present_block_ms = 0;
+
+        return ms;
+}
+
 void update_screen()
 {
 #ifndef NDEBUG
@@ -241,7 +253,11 @@ void update_screen()
 
         composite_display_textures();
 
+        const uint32_t present_start_ms = SDL_GetTicks();
+
         SDL_RenderPresent(g_sdl_renderer);
+
+        s_last_present_block_ms = SDL_GetTicks() - present_start_ms;
 
 #ifndef NDEBUG
         if (is_game_state) {

--- a/src/map_travel.cpp
+++ b/src/map_travel.cpp
@@ -314,7 +314,7 @@ void go_to_nxt()
 
         actor::player_state::g_target = nullptr;
 
-        viewport::show(map::g_player->m_pos, viewport::ForceCentering::yes);
+        viewport::cut_to(map::g_player->m_pos);
 
         map::update_vision();
 

--- a/src/marker.cpp
+++ b/src/marker.cpp
@@ -179,8 +179,9 @@ void MarkerState::on_start()
 
         // Dragging pans the view with the marker fixed at the centering
         // point - center the view on the marker so that the marker and
-        // the center "pin" coincide from the start
-        viewport::show(m_pos, viewport::ForceCentering::yes);
+        // the center "pin" coincide from the start. A cut: they must
+        // coincide immediately, not once a glide has landed.
+        viewport::cut_to(m_pos);
 
         on_moved();
 }
@@ -190,7 +191,7 @@ void MarkerState::on_window_resized()
         // This is safe and convenient:
         m_pos = map::g_player->m_pos;
 
-        viewport::show(m_pos, viewport::ForceCentering::yes);
+        viewport::cut_to(m_pos);
 
         msg_log::clear();
 }

--- a/src/menu_descr_page.cpp
+++ b/src/menu_descr_page.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/menu_page.cpp
+++ b/src/menu_page.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================
@@ -30,9 +30,6 @@ static const int s_value_column_gap = 2;
 
 // How far the divider rules extend beyond the list block on each side
 static const int s_divider_pad = 6;
-
-// Reach beyond an entry's text that still counts as tapping it, in gui cells
-static const int s_entry_tap_margin = 2;
 
 // -----------------------------------------------------------------------------
 // Global namespace
@@ -449,8 +446,8 @@ bool MenuPageState::try_tap(const P& logical_px)
         // The entry's own text marks it, NOT the whole row - the list block
         // is padded out to the divider width, and a row test would steal
         // taps meant to confirm the marked entry
-        if ((gui_pos.x < (m_drawn_entry_x0 - s_entry_tap_margin)) ||
-            (gui_pos.x > (m_drawn_entry_x1[row] + s_entry_tap_margin))) {
+        if ((gui_pos.x < (m_drawn_entry_x0 - g_entry_tap_margin)) ||
+            (gui_pos.x > (m_drawn_entry_x1[row] + g_entry_tap_margin))) {
                 return false;
         }
 

--- a/src/menu_page.cpp
+++ b/src/menu_page.cpp
@@ -31,6 +31,9 @@ static const int s_value_column_gap = 2;
 // How far the divider rules extend beyond the list block on each side
 static const int s_divider_pad = 6;
 
+// Reach beyond an entry's text that still counts as tapping it, in gui cells
+static const int s_entry_tap_margin = 2;
+
 // -----------------------------------------------------------------------------
 // Global namespace
 // -----------------------------------------------------------------------------
@@ -252,8 +255,8 @@ void MenuPageState::draw()
 
         // The list block: the labels padded out to the stylistic divider
         // width, centered on the labels. This is the width of the divider
-        // rules (where they are drawn), of the row tap zone, and of the
-        // scroll fades.
+        // rules (where they are drawn) and of the scroll fades - NOT of the
+        // tap zone, which is the entry's own text (see try_tap).
         const int row_w =
                 std::clamp(
                         block_w + (2 * s_divider_pad),
@@ -275,11 +278,21 @@ void MenuPageState::draw()
                 draw_menu_divider(row_x0, row_x1, y0 + nr_shown);
         }
 
+        m_drawn_entry_x1.clear();
+
         // Entries
         for (int i = idx_range_shown.min; i <= idx_range_shown.max; ++i) {
                 const auto& entry = entries[i];
 
                 const int y = y0 + (i - idx_range_shown.min);
+
+                // Through the value column where there is one, so that
+                // tapping a value hits its row
+                m_drawn_entry_x1.push_back(
+                        entry.value.empty()
+                                ? (x0 + (int)entry.label.size() - 1)
+                                : (x0 + label_w + s_value_column_gap +
+                                   (int)entry.value.size() - 1));
 
                 if (entry.is_header) {
                         io::draw_text(
@@ -354,8 +367,7 @@ void MenuPageState::draw()
 
         // Record the list geometry for tap mapping
         m_drawn_list_y0 = y0;
-        m_drawn_row_x0 = row_x0;
-        m_drawn_row_x1 = row_x1;
+        m_drawn_entry_x0 = x0;
 
         // Remember the marked entry, so a later re-entry of this page
         // restores it
@@ -428,15 +440,23 @@ bool MenuPageState::try_tap(const P& logical_px)
                 logical_px.x / config::gui_cell_px_w(),
                 logical_px.y / config::gui_cell_px_h());
 
-        if ((gui_pos.x < m_drawn_row_x0) ||
-            (gui_pos.x > m_drawn_row_x1)) {
+        const int row = gui_pos.y - m_drawn_list_y0;
+
+        if ((row < 0) || (row >= (int)m_drawn_entry_x1.size())) {
+                return false;
+        }
+
+        // The entry's own text marks it, NOT the whole row - the list block
+        // is padded out to the divider width, and a row test would steal
+        // taps meant to confirm the marked entry
+        if ((gui_pos.x < (m_drawn_entry_x0 - s_entry_tap_margin)) ||
+            (gui_pos.x > (m_drawn_entry_x1[row] + s_entry_tap_margin))) {
                 return false;
         }
 
         const auto idx_range_shown = m_browser.range_shown();
 
-        const int idx =
-                idx_range_shown.min + (gui_pos.y - m_drawn_list_y0);
+        const int idx = idx_range_shown.min + row;
 
         if ((idx < idx_range_shown.min) || (idx > idx_range_shown.max)) {
                 return false;

--- a/src/msg_log.cpp
+++ b/src/msg_log.cpp
@@ -695,6 +695,18 @@ void add(
         map::g_player->on_log_msg_printed();
 }
 
+void set_more_prompt_hint_shown(const bool is_shown)
+{
+        s_is_waiting_more_pompt = is_shown;
+
+        // As in more_prompt - the message must not fade out from under the
+        // hint that is asking to have it read
+        s_msg_fade_state =
+                is_shown
+                ? MsgFadeState::prevent_fade
+                : MsgFadeState::done;
+}
+
 void more_prompt()
 {
         // If the current log is empty, do nothing.

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -74,9 +74,6 @@ struct ChoiceRow
 
 static std::vector<ChoiceRow> s_choice_rows;
 
-// Reach beyond an entry's text that still counts as tapping it, in gui cells
-static const int s_entry_tap_margin = 2;
-
 static void reset_recorded_tap_areas()
 {
         s_ok_button_area = {-1, -1, -1, -1};
@@ -668,8 +665,8 @@ bool MenuPopupState::try_tap(const P& logical_px)
         // marked entry
         for (const auto& row : s_choice_rows) {
                 if ((row.y == gui_pos.y) &&
-                    (gui_pos.x >= (row.x0 - s_entry_tap_margin)) &&
-                    (gui_pos.x <= (row.x1 + s_entry_tap_margin))) {
+                    (gui_pos.x >= (row.x0 - g_entry_tap_margin)) &&
+                    (gui_pos.x <= (row.x1 + g_entry_tap_margin))) {
                         m_browser.set_y(row.idx);
 
                         break;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -56,28 +56,29 @@ static int max_msg_w()
         return 74;
 }
 
-// Tracks the extent of the popup box drawn this frame (used for closing the
-// popup when tapping outside it on touch devices)
-static R s_recorded_box_area = {-1, -1, -1, -1};
-
 // Tappable confirm/cancel button areas drawn at the bottom of popups on
 // touch devices (gui cell coordinates)
 static R s_ok_button_area = {-1, -1, -1, -1};
 static R s_cancel_button_area = {-1, -1, -1, -1};
 
-// Menu choice rows of the most recently drawn menu popup: screen gui row
-// and the choice index on that row (for tapping entries directly)
+// Menu choice rows of the most recently drawn menu popup: gui row, choice
+// index, and the drawn extent of the choice text (for tapping entries
+// directly)
 struct ChoiceRow
 {
         int y;
         int idx;
+        int x0;
+        int x1;
 };
 
 static std::vector<ChoiceRow> s_choice_rows;
 
-static void reset_recorded_box_area()
+// Reach beyond an entry's text that still counts as tapping it, in gui cells
+static const int s_entry_tap_margin = 2;
+
+static void reset_recorded_tap_areas()
 {
-        s_recorded_box_area = {-1, -1, -1, -1};
         s_ok_button_area = {-1, -1, -1, -1};
         s_cancel_button_area = {-1, -1, -1, -1};
 
@@ -136,30 +137,8 @@ static void draw_popup_buttons(const int y, const bool with_cancel)
         }
 }
 
-static void record_box_line(const int line_w, const int line_y)
-{
-        const auto screen_center_x = panels::center_x(Panel::screen);
-
-        const int x0 = screen_center_x - (line_w / 2) - 1;
-        const int x1 = screen_center_x + (line_w / 2) + 1;
-
-        if (s_recorded_box_area.p0.x < 0) {
-                s_recorded_box_area = {x0, line_y, x1, line_y};
-        }
-        else {
-                R& r = s_recorded_box_area;
-
-                r.p0.x = std::min(r.p0.x, x0);
-                r.p1.x = std::max(r.p1.x, x1);
-                r.p0.y = std::min(r.p0.y, line_y);
-                r.p1.y = std::max(r.p1.y, line_y);
-        }
-}
-
 static void draw_horizontal_line(const int line_w, const int line_y)
 {
-        record_box_line(line_w, line_y);
-
         const auto screen_center_x = panels::center_x(Panel::screen);
 
         const int x0 = screen_center_x - (line_w / 2);
@@ -363,7 +342,7 @@ void MsgPopupState::draw()
                         g_divider_min_w,
                         g_divider_max_w);
 
-        reset_recorded_box_area();
+        reset_recorded_tap_areas();
 
         draw_box(panels::screen_box_area());
 
@@ -522,7 +501,7 @@ void MenuPopupState::draw()
                 horizontal_line_w = std::min(horizontal_line_w, text_max_w);
         }
 
-        reset_recorded_box_area();
+        reset_recorded_tap_areas();
 
         draw_box(panels::screen_box_area());
 
@@ -573,7 +552,11 @@ void MenuPopupState::draw()
         for (size_t i = 0; i < m_menu_choices.size(); ++i) {
                 const auto choice_str = m_menu_choices[i];
 
-                s_choice_rows.push_back({y, (int)i});
+                s_choice_rows.push_back(
+                        {y,
+                         (int)i,
+                         choice_x_pos,
+                         choice_x_pos + (int)choice_str.size() - 1});
 
                 const int key_str_len = menu_key_prefix_len(choice_str);
 
@@ -680,13 +663,13 @@ bool MenuPopupState::try_tap(const P& logical_px)
                 logical_px.x / config::gui_cell_px_w(),
                 logical_px.y / config::gui_cell_px_h());
 
-        if ((gui_pos.x < s_recorded_box_area.p0.x) ||
-            (gui_pos.x > s_recorded_box_area.p1.x)) {
-                return false;
-        }
-
+        // The choice's own text marks it, NOT the whole row - the rows span
+        // the popup, so a row test would steal taps meant to confirm the
+        // marked entry
         for (const auto& row : s_choice_rows) {
-                if (row.y == gui_pos.y) {
+                if ((row.y == gui_pos.y) &&
+                    (gui_pos.x >= (row.x0 - s_entry_tap_margin)) &&
+                    (gui_pos.x <= (row.x1 + s_entry_tap_margin))) {
                         m_browser.set_y(row.idx);
 
                         break;
@@ -773,7 +756,7 @@ void NumberQueryPopupState::draw()
                 horizontal_line_w = std::min(horizontal_line_w, text_max_w);
         }
 
-        reset_recorded_box_area();
+        reset_recorded_tap_areas();
 
         draw_box(panels::screen_box_area());
 
@@ -978,11 +961,6 @@ void NumberQueryPopupState::update()
                 m_has_player_entered_value = true;
                 m_is_empty_nr = false;
         }
-}
-
-R box_area()
-{
-        return s_recorded_box_area;
 }
 
 R ok_button_area()

--- a/src/screen_shake.cpp
+++ b/src/screen_shake.cpp
@@ -1,0 +1,69 @@
+// =============================================================================
+// Copyright Werewolf Camp
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// =============================================================================
+
+#include "screen_shake.hpp"
+
+#include <algorithm>
+
+#include "config.hpp"
+#include "io_display.hpp"
+
+// -----------------------------------------------------------------------------
+// Private
+// -----------------------------------------------------------------------------
+static const uint32_t s_blow_duration_ms = 110;
+static const uint32_t s_damaged_duration_ms = 180;
+
+// The bot plays without a screen to shake
+static bool is_shake_wanted()
+{
+        return !config::is_bot_playing();
+}
+
+// -----------------------------------------------------------------------------
+// screen_shake
+// -----------------------------------------------------------------------------
+namespace screen_shake
+{
+void on_player_blow()
+{
+        if (!is_shake_wanted()) {
+                return;
+        }
+
+        const int amplitude = std::max(2, io::max_map_shake_px() / 3);
+
+        io::start_map_shake(amplitude, s_blow_duration_ms);
+}
+
+void on_player_damaged(const int dmg, const int max_hp)
+{
+        if (!is_shake_wanted() || (dmg <= 0)) {
+                return;
+        }
+
+        const int max_amplitude = std::max(2, io::max_map_shake_px() / 2);
+
+        // Full amplitude at half the player's max hp in one blow
+        const int amplitude =
+                std::clamp(
+                        (max_amplitude * dmg * 2) / std::max(1, max_hp),
+                        2,
+                        max_amplitude);
+
+        io::start_map_shake(amplitude, s_damaged_duration_ms);
+}
+
+void on_explosion(const uint32_t duration_ms)
+{
+        if (!is_shake_wanted()) {
+                return;
+        }
+
+        io::start_map_shake(io::max_map_shake_px(), duration_ms);
+}
+
+}  // namespace screen_shake

--- a/src/scrollbar.cpp
+++ b/src/scrollbar.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -371,7 +371,7 @@ void teleport(
         actor.m_pos = pos;
 
         if (actor::is_player(&actor)) {
-                viewport::show(map::g_player->m_pos, viewport::ForceCentering::yes);
+                viewport::cut_to(map::g_player->m_pos);
         }
 
         map::update_vision();

--- a/src/text_page.cpp
+++ b/src/text_page.cpp
@@ -1,5 +1,5 @@
 // =============================================================================
-// Copyright Martin Törnqvist <m.tornq@gmail.com>
+// Copyright Werewolf Camp
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // =============================================================================

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -25,7 +25,7 @@ const std::string g_version_str = "v23.0.0";
 // versionName/versionCode in android/app/build.gradle.kts in sync for
 // local builds. The "-alpha" phase suffix is manual - dropping it when
 // the port leaves alpha is a deliberate decision, not a tag format.
-const std::string g_build_version_str = g_version_str + ".6-alpha";
+const std::string g_build_version_str = g_version_str + ".7-alpha";
 const std::string g_copyright_str = "(c) 2011-2025 Martin Tornqvist";
 const std::string g_license_str = "Infra Arcana is free software, see LICENSE.txt.";
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -34,6 +34,10 @@ static P s_pan_anchor_player_pos;
 // lets the camera glide further than the one cell of overscan
 static P s_camera_whole_cells = {0, 0};
 
+// Whether the centering point is biased by the overlays (see
+// set_center_bias_enabled)
+static bool s_is_center_bias_enabled = true;
+
 static P get_view_dims()
 {
         const auto map_panel_gui_dims = panels::dims(Panel::map);
@@ -72,6 +76,11 @@ static int dpad_cells()
 static P visible_view_center()
 {
         const auto view_dims = get_view_dims();
+
+        if (!s_is_center_bias_enabled) {
+                // Nothing is taking a column - dead center
+                return {view_dims.x / 2, view_dims.y / 2};
+        }
 
         const int side_cells = side_panel_cells();
 
@@ -176,6 +185,11 @@ void cut_to(const P& map_pos)
 void advance_camera()
 {
         place_view_origin(camera_target());
+}
+
+void set_center_bias_enabled(const bool is_enabled)
+{
+        s_is_center_bias_enabled = is_enabled;
 }
 
 void cut_camera()

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -7,7 +7,6 @@
 #include "viewport.hpp"
 
 #include <algorithm>
-#include <cstdlib>
 
 #include "actor.hpp"
 #include "config.hpp"
@@ -30,6 +29,10 @@ static P s_p0;
 // not follow the player - until the player moves from the anchor position.
 static bool s_pan_active = false;
 static P s_pan_anchor_player_pos;
+
+// Whole cells of camera lag baked into s_p0 (see place_view_origin) - what
+// lets the camera glide further than the one cell of overscan
+static P s_camera_whole_cells = {0, 0};
 
 static P get_view_dims()
 {
@@ -93,6 +96,47 @@ static P visible_view_center()
                 view_dims.y / 2};
 }
 
+// The framing the camera is heading for
+static P camera_target()
+{
+        return s_p0 - s_camera_whole_cells;
+}
+
+// Draws the view where the camera IS: the target, offset by the whole cells
+// it is behind. The composite carries the sub-cell remainder.
+static void place_view_origin(const P& target)
+{
+        const P p0_before = s_p0;
+
+        s_camera_whole_cells = io::map_follow_whole_cells();
+
+        io::set_map_follow_drawn_whole_cells(s_camera_whole_cells);
+
+        s_p0 = target + s_camera_whole_cells;
+
+        // TODO: Instead of clearing all flash animations, it would be better to update their
+        // positions. This prevents showing an attack flash animation the player if they are knocked
+        // back (typically changes the viewport).
+        if (s_p0 != p0_before) {
+                io::clear_all_flash_animations();
+        }
+}
+
+// Aims the camera at a new target. It stays where it is and becomes that
+// much further behind, easing up per present (see io::offset_map_follow).
+static void glide_view_to(const P& target)
+{
+        const P target_delta = target - camera_target();
+
+        if (target_delta != P(0, 0)) {
+                io::offset_map_follow(
+                        P(-target_delta.x * config::map_cell_px_w(),
+                          -target_delta.y * config::map_cell_px_h()));
+        }
+
+        place_view_origin(target);
+}
+
 // -----------------------------------------------------------------------------
 // viewport
 // -----------------------------------------------------------------------------
@@ -109,42 +153,44 @@ R get_map_view_area()
 
 void show(const P& map_pos, const ForceCentering force_centering)
 {
-        const auto centered_pos = map_pos - visible_view_center();
-
-        const P p0_before = s_p0;
-
         if (force_centering == ForceCentering::yes) {
-                // A forced centering (aiming outside the view, entering a new
-                // level, ...) always ends any manual camera pan
+                // A forced centering (aiming outside the view, returning to
+                // the player after a manual pan, ...) ends any manual pan
                 s_pan_active = false;
         }
 
         // The view is always centered on the focused position: a phone screen
-        // shows too few cells to let the player walk near its edge, and a
-        // single step of the camera is what the follow tween below animates
-        s_p0 = centered_pos;
+        // shows too few cells to let the player walk near its edge
+        glide_view_to(map_pos - visible_view_center());
+}
 
-        // TODO: Instead of clearing all flash animations, it would be better to update their
-        // positions. This prevents showing an attack flash animation the player if they are knocked
-        // back (typically changes the viewport).
-        if (s_p0 != p0_before) {
-                io::clear_all_flash_animations();
+void cut_to(const P& map_pos)
+{
+        s_pan_active = false;
 
-                // A single step (following the player around) slides the
-                // camera with a quick tween instead of snapping tile to
-                // tile. Anything longer (new level, entering/leaving
-                // targeting, snapping back after a manual pan) stays
-                // instant - and could not be shown anyway: the map display
-                // carries exactly ONE cell of overscan, which is all the
-                // scroll offset the composite can sample (see io_display).
-                const P delta = s_p0 - p0_before;
+        io::cancel_map_follow();
 
-                if ((std::abs(delta.x) <= 1) && (std::abs(delta.y) <= 1)) {
-                        io::start_map_follow_tween(
-                                P(-delta.x * config::map_cell_px_w(),
-                                  -delta.y * config::map_cell_px_h()));
-                }
-        }
+        place_view_origin(map_pos - visible_view_center());
+}
+
+void advance_camera()
+{
+        place_view_origin(camera_target());
+}
+
+void cut_camera()
+{
+        io::cancel_map_follow();
+
+        // s_p0 keeps its whole cells - the camera stays where it is drawn
+        s_camera_whole_cells = {0, 0};
+
+        io::set_map_follow_drawn_whole_cells({0, 0});
+}
+
+bool is_camera_redraw_needed()
+{
+        return io::map_follow_whole_cells() != s_camera_whole_cells;
 }
 
 void pan(const P& cell_delta)
@@ -173,6 +219,9 @@ void pan(const P& cell_delta)
                         std::min(limits.p0.y, s_p0.y),
                         std::max(limits.p1.y, s_p0.y));
 
+        // The finger owns the origin now - a glide in flight would fight it
+        cut_camera();
+
         if (!s_pan_active) {
                 s_pan_active = true;
 
@@ -190,8 +239,8 @@ bool should_auto_center()
         }
 
         if (map::g_player->m_pos != s_pan_anchor_player_pos) {
-                // The player has moved - drop the manual pan, and snap the
-                // camera back to following the player
+                // The player has moved - drop the manual pan, and let the
+                // camera glide back to following the player
                 s_pan_active = false;
 
                 return true;
@@ -207,11 +256,9 @@ void end_pan()
 
 void end_pan_and_center_on_player()
 {
-        // NOTE: The centering must be forced - the view may be off center
-        // (or even beyond the map edges) with the player still inside it,
-        // and show() alone only guarantees that the position is visible
         end_pan();
 
+        // Not a cut - the camera glides back from wherever the pan left it
         show(map::g_player->m_pos, ForceCentering::yes);
 }
 


### PR DESCRIPTION
- Smoothed camera follow
- Eased camera return after drag-to-look
- Tightened menu entry tap surface
- Added screen shake to hits and kicks
- Strengthened explosion shake
- Added death sequence, tap to skip
- Paced frames to the display refresh